### PR TITLE
Active Page Retry Delay Added. Fix to Background Script not sending New Tabs

### DIFF
--- a/src/client/app/actions/User/UserActions.js
+++ b/src/client/app/actions/User/UserActions.js
@@ -66,9 +66,10 @@ export function getPageInformation(token, count){
          dispatch(receivePageInfo(json))
        })
        .catch(e => {
-          // console.log("Error caught. Retrying: ", e);
-          if(count < 100){
-            dispatch(getPageInformation(token, count + 1));
+          if(count < 10){
+            console.log("retrying to fetch active page", e);
+            setTimeout(function() { dispatch(getPageInformation(token, count + 1)); }, 1000);
+
           } else {
             dispatch(updatePopupStatus(PopupConstants.NoContent))
           }

--- a/src/client/chrome/scripts/background.js
+++ b/src/client/chrome/scripts/background.js
@@ -19,18 +19,16 @@ chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
           var dom = "";
         }
         var domain = tab.url.replace('http://','').replace('https://','').split(/[/?#]/)[0];
-        if(tab.url != 'chrome://newtab/'){
-          fetch('https://hindsite2020.herokuapp.com/newpage/', {
-            headers: {
-              'Accept': 'application/json',
-              'Content-Type': 'application/json',
-              'Authorization': "Token " + token
-            },
-            method: "POST",
-            body: JSON.stringify({"tab":tab.id, "title":tab.title, "domain":domain, "url":tab.url, "favIconUrl":tab.favIconUrl, "previousTabId": tab.openerTabId, "active": tab.active, "html": dom})
-          }
-        );
-      }
+        fetch('https://hindsite2020.herokuapp.com/newpage/', {
+          headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+            'Authorization': "Token " + token
+          },
+          method: "POST",
+          body: JSON.stringify({"tab":tab.id, "title":tab.title, "domain":domain, "url":tab.url, "favIconUrl":tab.favIconUrl, "previousTabId": tab.openerTabId, "active": tab.active, "html": dom})
+        }
+      );
     });
     closed = false;
   }
@@ -61,17 +59,16 @@ chrome.tabs.onActivated.addListener(function (activeInfo){
           var dom = "";
         }
         var domain = tab.url.replace('http://','').replace('https://','').split(/[/?#]/)[0];
-        if(tab.url != 'chrome://newtab/'){
-          fetch('https://hindsite2020.herokuapp.com/active/', {
-            headers: {
-              'Accept': 'application/json',
-              'Content-Type': 'application/json',
-              'Authorization': "Token " + token
-            },
-            method: "POST",
-            body: JSON.stringify({"tab": activeInfo.tabId, "closed": closed, "title":tab.title, "domain":domain, "url":tab.url, "favIconUrl":tab.favIconUrl, "previousTabId": tab.openerTabId, "active": tab.active, "html": dom})
-          });
-        }
+        fetch('https://hindsite2020.herokuapp.com/active/', {
+          headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+            'Authorization': "Token " + token
+          },
+          method: "POST",
+          body: JSON.stringify({"tab": activeInfo.tabId, "closed": closed, "title":tab.title, "domain":domain, "url":tab.url, "favIconUrl":tab.favIconUrl, "previousTabId": tab.openerTabId, "active": tab.active, "html": dom})
+        });
+      }
         closed = false;
       });
     });


### PR DESCRIPTION
Added 1 second delay to retry with a maximum of 10 tries before timeout #170

The background script does need to send the backend when the chrome://newtab is openned so the backend can know when to return 204 'no contents' to the popup to signify a loading tab. Also needed so the popup will display the navigate to a new tab message when at chrome://newtab instead of the old tabs 's info.